### PR TITLE
Add resilient app-server client with auto-restart and retry policies

### DIFF
--- a/src/JKToolKit.CodexSDK.Demo/Commands/AppServerResilientStream/AppServerResilientStreamCommand.cs
+++ b/src/JKToolKit.CodexSDK.Demo/Commands/AppServerResilientStream/AppServerResilientStreamCommand.cs
@@ -1,0 +1,167 @@
+using JKToolKit.CodexSDK.AppServer;
+using JKToolKit.CodexSDK.AppServer.Notifications;
+using JKToolKit.CodexSDK.AppServer.Resiliency;
+using JKToolKit.CodexSDK.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Spectre.Console.Cli;
+
+namespace JKToolKit.CodexSDK.Demo.Commands.AppServerResilientStream;
+
+public sealed class AppServerResilientStreamCommand : AsyncCommand<AppServerResilientStreamSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, AppServerResilientStreamSettings settings, CancellationToken cancellationToken)
+    {
+        var repoPath = settings.RepoPath ?? Directory.GetCurrentDirectory();
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (settings.TimeoutSeconds is > 0)
+        {
+            cts.CancelAfter(TimeSpan.FromSeconds(settings.TimeoutSeconds.Value));
+        }
+
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            cts.Cancel();
+        };
+        var ct = cts.Token;
+
+        var model = string.IsNullOrWhiteSpace(settings.Model)
+            ? CodexModel.Gpt52Codex
+            : CodexModel.Parse(settings.Model);
+
+        var approvalPolicy = string.IsNullOrWhiteSpace(settings.ApprovalPolicy)
+            ? CodexApprovalPolicy.Never
+            : CodexApprovalPolicy.Parse(settings.ApprovalPolicy);
+
+        var sandbox = string.IsNullOrWhiteSpace(settings.Sandbox)
+            ? CodexSandboxMode.WorkspaceWrite
+            : CodexSandboxMode.Parse(settings.Sandbox);
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b
+            .SetMinimumLevel(LogLevel.Warning)
+            .AddConsole());
+
+        services.AddCodexAppServerClient(o =>
+        {
+            o.CodexExecutablePath = settings.CodexExecutablePath;
+            o.CodexHomeDirectory = settings.CodexHomeDirectory;
+            o.DefaultClientInfo = new("ncodexsdk-demo", "JKToolKit.CodexSDK Resilient AppServer Demo", "1.0.0");
+        });
+
+        services.AddCodexResilientAppServerClient(o =>
+        {
+            // Safe default: auto-restart on, no automatic retries (user decides via RetryPolicy).
+            o.AutoRestart = true;
+            o.NotificationsContinueAcrossRestarts = true;
+            o.EmitRestartMarkerNotifications = true;
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        try
+        {
+            var factory = sp.GetRequiredService<ICodexResilientAppServerClientFactory>();
+            await using var codex = await factory.StartAsync(ct);
+
+            using var notificationsCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var notificationsTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var n in codex.Notifications(notificationsCts.Token))
+                    {
+                        if (n is ClientRestartedNotification r)
+                        {
+                            Console.Error.WriteLine(
+                                $"[resiliency] restarted #{r.RestartCount} (exit={r.PreviousExitCode?.ToString() ?? "?"})");
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (notificationsCts.IsCancellationRequested)
+                {
+                    // ignore
+                }
+            }, notificationsCts.Token);
+
+            var thread = await codex.StartThreadAsync(new ThreadStartOptions
+            {
+                Model = model,
+                Cwd = repoPath,
+                ApprovalPolicy = approvalPolicy,
+                Sandbox = sandbox
+            }, ct);
+
+            await RunTurnAsync(codex, thread.Id, settings.Prompt, ct);
+
+            if (settings.RestartBetweenTurns)
+            {
+                Console.Error.WriteLine("[resiliency] forcing a manual restart...");
+                await codex.RestartAsync(ct);
+
+                // Best-effort: threads may be resumable across restarts depending on Codex persistence.
+                try
+                {
+                    await codex.ResumeThreadAsync(thread.Id, ct);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[resiliency] thread resume failed, continuing with same id anyway: {ex.Message}");
+                }
+            }
+
+            await RunTurnAsync(codex, thread.Id, settings.Prompt2, ct);
+
+            notificationsCts.Cancel();
+            try { await notificationsTask.ConfigureAwait(false); } catch { /* ignore */ }
+
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
+        finally
+        {
+            if (sp is IAsyncDisposable ad)
+                await ad.DisposeAsync();
+            else
+                (sp as IDisposable)?.Dispose();
+        }
+    }
+
+    private static async Task RunTurnAsync(
+        ResilientCodexAppServerClient codex,
+        string threadId,
+        string prompt,
+        CancellationToken ct)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"> {prompt}");
+        Console.WriteLine();
+
+        await using var turn = await codex.StartTurnAsync(threadId, new TurnStartOptions
+        {
+            Input = [TurnInputItem.Text(prompt)]
+        }, ct);
+
+        await foreach (var ev in turn.Events(ct))
+        {
+            if (ev is AgentMessageDeltaNotification delta)
+            {
+                Console.Write(delta.Delta);
+            }
+        }
+
+        var completed = await turn.Completion;
+        Console.WriteLine($"\nDone: {completed.Status}");
+    }
+}
+

--- a/src/JKToolKit.CodexSDK.Demo/Commands/AppServerResilientStream/AppServerResilientStreamSettings.cs
+++ b/src/JKToolKit.CodexSDK.Demo/Commands/AppServerResilientStream/AppServerResilientStreamSettings.cs
@@ -1,0 +1,37 @@
+using Spectre.Console.Cli;
+
+namespace JKToolKit.CodexSDK.Demo.Commands.AppServerResilientStream;
+
+public sealed class AppServerResilientStreamSettings : CommandSettings
+{
+    [CommandOption("--repo <PATH>")]
+    public string? RepoPath { get; init; }
+
+    [CommandOption("--codex-path <PATH>")]
+    public string? CodexExecutablePath { get; init; }
+
+    [CommandOption("--codex-home <DIR>")]
+    public string? CodexHomeDirectory { get; init; }
+
+    [CommandOption("--timeout-seconds <SECONDS>")]
+    public int? TimeoutSeconds { get; init; }
+
+    [CommandOption("--model <MODEL>")]
+    public string? Model { get; init; }
+
+    [CommandOption("--approval-policy <POLICY>")]
+    public string? ApprovalPolicy { get; init; }
+
+    [CommandOption("--sandbox <MODE>")]
+    public string? Sandbox { get; init; }
+
+    [CommandOption("--restart-between-turns")]
+    public bool RestartBetweenTurns { get; init; }
+
+    [CommandOption("--prompt <TEXT>")]
+    public string Prompt { get; init; } = "Summarize this repo.";
+
+    [CommandOption("--prompt2 <TEXT>")]
+    public string Prompt2 { get; init; } = "List the top 5 important folders/files and what they do.";
+}
+

--- a/src/JKToolKit.CodexSDK.Demo/JKToolKit.CodexSDK.Demo.csproj
+++ b/src/JKToolKit.CodexSDK.Demo/JKToolKit.CodexSDK.Demo.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
   </ItemGroup>

--- a/src/JKToolKit.CodexSDK.Demo/Program.cs
+++ b/src/JKToolKit.CodexSDK.Demo/Program.cs
@@ -1,4 +1,5 @@
 using JKToolKit.CodexSDK.Demo.Commands.AppServerApproval;
+using JKToolKit.CodexSDK.Demo.Commands.AppServerResilientStream;
 using JKToolKit.CodexSDK.Demo.Commands.AppServerStream;
 using JKToolKit.CodexSDK.Demo.Commands.Exec;
 using JKToolKit.CodexSDK.Demo.Commands.McpServer;
@@ -25,6 +26,9 @@ internal static class Program
 
             config.AddCommand<AppServerStreamCommand>("appserver-stream")
                 .WithDescription("Start `codex app-server` and stream turn output.");
+
+            config.AddCommand<AppServerResilientStreamCommand>("appserver-resilient-stream")
+                .WithDescription("Start `codex app-server` with auto-restart enabled and stream turn output.");
 
             config.AddCommand<AppServerApprovalCommand>("appserver-approval")
                 .WithDescription("Start `codex app-server` with a restrictive manual approval handler.");

--- a/src/JKToolKit.CodexSDK/AppServer/Notifications/ClientRestartedNotification.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Notifications/ClientRestartedNotification.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+
+namespace JKToolKit.CodexSDK.AppServer.Notifications;
+
+/// <summary>
+/// A local (client-side) marker notification emitted by resilient wrappers when the app-server subprocess is restarted.
+/// </summary>
+public sealed record class ClientRestartedNotification : AppServerNotification
+{
+    /// <summary>
+    /// Gets the restart count for the resilient client lifetime.
+    /// </summary>
+    public int RestartCount { get; }
+
+    /// <summary>
+    /// Gets the previous subprocess exit code, when known.
+    /// </summary>
+    public int? PreviousExitCode { get; }
+
+    /// <summary>
+    /// Gets the restart timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; }
+
+    /// <summary>
+    /// Gets the reason string, when available.
+    /// </summary>
+    public string? Reason { get; }
+
+    /// <summary>
+    /// Gets a best-effort tail of stderr captured from the previous subprocess (may be empty).
+    /// </summary>
+    public IReadOnlyList<string> PreviousStderrTail { get; }
+
+    /// <summary>
+    /// Initializes a new marker notification.
+    /// </summary>
+    public ClientRestartedNotification(
+        int restartCount,
+        int? previousExitCode,
+        DateTimeOffset timestamp,
+        string? reason,
+        IReadOnlyList<string>? previousStderrTail)
+        : base(
+            method: "client/restarted",
+            @params: JsonSerializer.SerializeToElement(new
+            {
+                restartCount,
+                previousExitCode,
+                timestamp = timestamp.UtcDateTime,
+                reason,
+                previousStderrTail = previousStderrTail ?? Array.Empty<string>()
+            }).Clone())
+    {
+        RestartCount = restartCount;
+        PreviousExitCode = previousExitCode;
+        Timestamp = timestamp;
+        Reason = reason;
+        PreviousStderrTail = previousStderrTail ?? Array.Empty<string>();
+    }
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerConnectionState.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerConnectionState.cs
@@ -1,0 +1,28 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Represents the current connection state for a resilient app-server client.
+/// </summary>
+public enum CodexAppServerConnectionState
+{
+    /// <summary>
+    /// The client is connected to a live app-server subprocess.
+    /// </summary>
+    Connected = 0,
+
+    /// <summary>
+    /// The client is currently attempting to restart the subprocess and reconnect.
+    /// </summary>
+    Restarting = 1,
+
+    /// <summary>
+    /// The client has permanently faulted (e.g. restart limit reached) and will not restart.
+    /// </summary>
+    Faulted = 2,
+
+    /// <summary>
+    /// The client has been disposed.
+    /// </summary>
+    Disposed = 3
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerOperationKind.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerOperationKind.cs
@@ -1,0 +1,33 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Identifies the kind of operation being performed against the app-server connection.
+/// </summary>
+public enum CodexAppServerOperationKind
+{
+    /// <summary>
+    /// A user-initiated JSON-RPC request via <c>CallAsync</c>.
+    /// </summary>
+    Call = 0,
+
+    /// <summary>
+    /// A user-initiated <c>thread/start</c> request.
+    /// </summary>
+    StartThread = 1,
+
+    /// <summary>
+    /// A user-initiated <c>thread/resume</c> request.
+    /// </summary>
+    ResumeThread = 2,
+
+    /// <summary>
+    /// A user-initiated <c>turn/start</c> request.
+    /// </summary>
+    StartTurn = 3,
+
+    /// <summary>
+    /// The internal notifications pump that bridges <c>Notifications()</c> across restarts.
+    /// </summary>
+    NotificationsPump = 4
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerResilienceOptions.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerResilienceOptions.cs
@@ -1,0 +1,42 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Options for enabling resiliency behaviors (auto-restart + optional retries) when using <c>codex app-server</c>.
+/// </summary>
+public sealed class CodexAppServerResilienceOptions
+{
+    /// <summary>
+    /// Gets or sets whether the resilient client should automatically restart the subprocess when it disconnects.
+    /// </summary>
+    public bool AutoRestart { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether <see cref="ResilientCodexAppServerClient.Notifications"/> should continue across restarts.
+    /// </summary>
+    public bool NotificationsContinueAcrossRestarts { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to emit a local <c>client/restarted</c> marker notification after a restart.
+    /// </summary>
+    public bool EmitRestartMarkerNotifications { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets restart limit and backoff settings.
+    /// </summary>
+    public CodexAppServerRestartPolicy RestartPolicy { get; set; } = CodexAppServerRestartPolicy.Default;
+
+    /// <summary>
+    /// Gets or sets the retry policy for user operations that fail due to disconnect.
+    /// </summary>
+    /// <remarks>
+    /// The default policy never retries, because automatically retrying requests can be unsafe depending
+    /// on the operation semantics. Library users can opt into retries as needed.
+    /// </remarks>
+    public CodexAppServerRetryPolicyDelegate RetryPolicy { get; set; } = CodexAppServerRetryPolicy.NeverRetry;
+
+    /// <summary>
+    /// Optional callback invoked after a restart completes (best-effort).
+    /// </summary>
+    public Action<CodexAppServerRestartEvent>? OnRestart { get; set; }
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRestartEvent.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRestartEvent.cs
@@ -1,0 +1,33 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Describes an app-server restart performed by a resilient client.
+/// </summary>
+public sealed record class CodexAppServerRestartEvent
+{
+    /// <summary>
+    /// Gets the cumulative restart count for the lifetime of the resilient client.
+    /// </summary>
+    public required int RestartCount { get; init; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the restart completed.
+    /// </summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets the previous subprocess exit code, when known.
+    /// </summary>
+    public int? PreviousExitCode { get; init; }
+
+    /// <summary>
+    /// Gets a short reason string for why the restart happened, when available.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Gets a best-effort tail of stderr captured from the previous subprocess, when available.
+    /// </summary>
+    public IReadOnlyList<string> PreviousStderrTail { get; init; } = Array.Empty<string>();
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRestartPolicy.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRestartPolicy.cs
@@ -1,0 +1,38 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Controls restart backoff and limits for a resilient app-server client.
+/// </summary>
+public sealed record class CodexAppServerRestartPolicy
+{
+    /// <summary>
+    /// Gets the maximum number of restarts allowed within <see cref="Window"/>.
+    /// </summary>
+    public int MaxRestarts { get; init; } = 5;
+
+    /// <summary>
+    /// Gets the sliding window used for restart limiting.
+    /// </summary>
+    public TimeSpan Window { get; init; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Gets the initial backoff delay applied after repeated restarts.
+    /// </summary>
+    public TimeSpan InitialBackoff { get; init; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Gets the maximum backoff delay.
+    /// </summary>
+    public TimeSpan MaxBackoff { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets the jitter fraction applied to backoff delays. A value of 0.2 means ±20%.
+    /// </summary>
+    public double JitterFraction { get; init; } = 0.2;
+
+    /// <summary>
+    /// Gets a default bounded restart policy (5 restarts per 60 seconds, exponential backoff capped at 10s).
+    /// </summary>
+    public static CodexAppServerRestartPolicy Default { get; } = new();
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRetryContext.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRetryContext.cs
@@ -1,0 +1,33 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Context passed to a retry policy when an operation fails due to disconnect.
+/// </summary>
+public sealed record class CodexAppServerRetryContext
+{
+    /// <summary>
+    /// Gets the operation kind.
+    /// </summary>
+    public required CodexAppServerOperationKind OperationKind { get; init; }
+
+    /// <summary>
+    /// Gets the retry attempt number (1-based).
+    /// </summary>
+    public required int Attempt { get; init; }
+
+    /// <summary>
+    /// Gets the exception that triggered the retry decision.
+    /// </summary>
+    public required Exception Exception { get; init; }
+
+    /// <summary>
+    /// Gets the cancellation token for the operation.
+    /// </summary>
+    public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Restarts/reconnects the app-server subprocess if needed.
+    /// </summary>
+    public required Func<CancellationToken, Task> EnsureRestartedAsync { get; init; }
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRetryDecision.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRetryDecision.cs
@@ -1,0 +1,42 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Decision returned by a retry policy.
+/// </summary>
+public sealed record class CodexAppServerRetryDecision
+{
+    /// <summary>
+    /// Gets whether the operation should be retried.
+    /// </summary>
+    public required bool ShouldRetry { get; init; }
+
+    /// <summary>
+    /// Gets an optional delay to wait before retrying.
+    /// </summary>
+    public TimeSpan? Delay { get; init; }
+
+    /// <summary>
+    /// Gets an optional hook to run before retrying (e.g. re-resume a thread).
+    /// </summary>
+    public Func<CancellationToken, Task>? BeforeRetryAsync { get; init; }
+
+    /// <summary>
+    /// Gets an optional reason for diagnostics/telemetry.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// A decision that indicates no retry.
+    /// </summary>
+    public static CodexAppServerRetryDecision NoRetry { get; } = new() { ShouldRetry = false };
+
+    /// <summary>
+    /// Creates a retry decision.
+    /// </summary>
+    public static CodexAppServerRetryDecision Retry(
+        TimeSpan? delay = null,
+        Func<CancellationToken, Task>? beforeRetryAsync = null,
+        string? reason = null) =>
+        new() { ShouldRetry = true, Delay = delay, BeforeRetryAsync = beforeRetryAsync, Reason = reason };
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRetryPolicy.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerRetryPolicy.cs
@@ -1,0 +1,19 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Provides built-in retry policies for resilient app-server clients.
+/// </summary>
+public static class CodexAppServerRetryPolicy
+{
+    /// <summary>
+    /// Never retries user operations. (The subprocess may still be restarted for future operations.)
+    /// </summary>
+    public static CodexAppServerRetryPolicyDelegate NeverRetry { get; } = _ =>
+        new ValueTask<CodexAppServerRetryDecision>(CodexAppServerRetryDecision.NoRetry);
+}
+
+/// <summary>
+/// Delegate used to decide whether an operation should be retried after a restart.
+/// </summary>
+public delegate ValueTask<CodexAppServerRetryDecision> CodexAppServerRetryPolicyDelegate(CodexAppServerRetryContext ctx);
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerUnavailableException.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/CodexAppServerUnavailableException.cs
@@ -1,0 +1,16 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Thrown when a resilient app-server client cannot connect (e.g. restart limit reached) and is faulted.
+/// </summary>
+public sealed class CodexAppServerUnavailableException : Exception
+{
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    public CodexAppServerUnavailableException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/ICodexResilientAppServerClientFactory.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/ICodexResilientAppServerClientFactory.cs
@@ -1,0 +1,13 @@
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Factory for starting resilient app-server clients.
+/// </summary>
+public interface ICodexResilientAppServerClientFactory
+{
+    /// <summary>
+    /// Starts a resilient app-server client (launches <c>codex app-server</c> and performs initialization).
+    /// </summary>
+    Task<ResilientCodexAppServerClient> StartAsync(CancellationToken ct = default);
+}
+

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/ResilientCodexAppServerClient.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/ResilientCodexAppServerClient.cs
@@ -1,0 +1,580 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using JKToolKit.CodexSDK.AppServer.Notifications;
+using JKToolKit.CodexSDK.Infrastructure.JsonRpc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// A resilient wrapper around <see cref="CodexAppServerClient"/> that can auto-restart the underlying
+/// <c>codex app-server</c> subprocess and (optionally) retry operations based on a user-provided policy.
+/// </summary>
+public sealed class ResilientCodexAppServerClient : IAsyncDisposable
+{
+    private readonly Func<CancellationToken, Task<ICodexAppServerClientAdapter>> _startInner;
+    private readonly CodexAppServerResilienceOptions _options;
+    private readonly ILogger _logger;
+
+    private readonly SemaphoreSlim _restartLock = new(1, 1);
+    private readonly CancellationTokenSource _disposeCts = new();
+    private readonly Queue<DateTimeOffset> _restartTimes = new();
+
+    private ICodexAppServerClientAdapter? _inner;
+    private long _innerVersion;
+    private int _restartCount;
+    private volatile CodexAppServerConnectionState _state = CodexAppServerConnectionState.Connected;
+    private volatile Exception? _fault;
+    private CodexAppServerDisconnectedException? _lastDisconnect;
+    private Task? _exitMonitorTask;
+
+    /// <summary>
+    /// Gets the current connection state.
+    /// </summary>
+    public CodexAppServerConnectionState State => _state;
+
+    /// <summary>
+    /// Gets the last restart event, when available.
+    /// </summary>
+    public CodexAppServerRestartEvent? LastRestart { get; private set; }
+
+    /// <summary>
+    /// Gets the number of restarts performed during this client's lifetime.
+    /// </summary>
+    public int RestartCount => Volatile.Read(ref _restartCount);
+
+    internal ResilientCodexAppServerClient(
+        Func<CancellationToken, Task<ICodexAppServerClientAdapter>> startInner,
+        CodexAppServerResilienceOptions options,
+        ILogger logger)
+    {
+        _startInner = startInner ?? throw new ArgumentNullException(nameof(startInner));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Starts a new resilient client using an underlying <see cref="ICodexAppServerClientFactory"/>.
+    /// </summary>
+    public static async Task<ResilientCodexAppServerClient> StartAsync(
+        ICodexAppServerClientFactory factory,
+        CodexAppServerResilienceOptions? options = null,
+        ILoggerFactory? loggerFactory = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var effectiveOptions = options ?? new CodexAppServerResilienceOptions();
+        var lf = loggerFactory ?? NullLoggerFactory.Instance;
+        var logger = lf.CreateLogger<ResilientCodexAppServerClient>();
+
+        var client = new ResilientCodexAppServerClient(
+            startInner: async c =>
+            {
+                var inner = await factory.StartAsync(c).ConfigureAwait(false);
+                return new CodexAppServerClientAdapter(inner);
+            },
+            options: effectiveOptions,
+            logger: logger);
+
+        await client.EnsureConnectedAsync(ct).ConfigureAwait(false);
+        return client;
+    }
+
+    /// <summary>
+    /// Returns a notification stream. When enabled, the stream continues across restarts.
+    /// </summary>
+    public async IAsyncEnumerable<AppServerNotification> Notifications([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _disposeCts.Token);
+        var linkedToken = linkedCts.Token;
+
+        while (true)
+        {
+            linkedToken.ThrowIfCancellationRequested();
+
+            var inner = await EnsureConnectedAsync(linkedToken).ConfigureAwait(false);
+            var version = Volatile.Read(ref _innerVersion);
+
+            Exception? terminal = null;
+            var enumerator = inner.Notifications(linkedToken).GetAsyncEnumerator(linkedToken);
+            try
+            {
+                while (true)
+                {
+                    bool moved;
+                    try
+                    {
+                        moved = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
+                    {
+                        yield break;
+                    }
+                    catch (Exception ex)
+                    {
+                        terminal = ex;
+                        break;
+                    }
+
+                    if (!moved)
+                    {
+                        terminal = new CodexAppServerDisconnectedException(
+                            message: "Codex app-server notifications stream ended unexpectedly.",
+                            processId: null,
+                            exitCode: null,
+                            stderrTail: Array.Empty<string>());
+                        break;
+                    }
+
+                    yield return enumerator.Current;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (terminal is null)
+            {
+                yield break;
+            }
+
+            if (!IsDisconnect(terminal))
+            {
+                throw terminal;
+            }
+
+            RememberDisconnect(terminal);
+
+            if (!_options.AutoRestart || !_options.NotificationsContinueAcrossRestarts)
+            {
+                throw terminal;
+            }
+
+            await EnsureRestartedAsync(version, terminal, reason: "notifications-disconnected", linkedToken).ConfigureAwait(false);
+
+            if (_options.EmitRestartMarkerNotifications && LastRestart is not null)
+            {
+                var e = LastRestart;
+                yield return new ClientRestartedNotification(
+                    restartCount: e.RestartCount,
+                    previousExitCode: e.PreviousExitCode,
+                    timestamp: e.Timestamp,
+                    reason: e.Reason,
+                    previousStderrTail: e.PreviousStderrTail);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sends an arbitrary JSON-RPC request to the app server.
+    /// </summary>
+    public Task<JsonElement> CallAsync(string method, object? @params, CancellationToken ct = default) =>
+        ExecuteWithPolicyAsync(CodexAppServerOperationKind.Call, c => c.CallAsync(method, @params, ct), ct);
+
+    /// <summary>
+    /// Starts a new thread.
+    /// </summary>
+    public Task<CodexThread> StartThreadAsync(ThreadStartOptions options, CancellationToken ct = default) =>
+        ExecuteWithPolicyAsync(CodexAppServerOperationKind.StartThread, c => c.StartThreadAsync(options, ct), ct);
+
+    /// <summary>
+    /// Resumes an existing thread by ID.
+    /// </summary>
+    public Task<CodexThread> ResumeThreadAsync(string threadId, CancellationToken ct = default) =>
+        ExecuteWithPolicyAsync(CodexAppServerOperationKind.ResumeThread, c => c.ResumeThreadAsync(threadId, ct), ct);
+
+    /// <summary>
+    /// Resumes an existing thread using the provided options.
+    /// </summary>
+    public Task<CodexThread> ResumeThreadAsync(ThreadResumeOptions options, CancellationToken ct = default) =>
+        ExecuteWithPolicyAsync(CodexAppServerOperationKind.ResumeThread, c => c.ResumeThreadAsync(options, ct), ct);
+
+    /// <summary>
+    /// Starts a new turn within the specified thread.
+    /// </summary>
+    public Task<CodexTurnHandle> StartTurnAsync(string threadId, TurnStartOptions options, CancellationToken ct = default) =>
+        ExecuteWithPolicyAsync(CodexAppServerOperationKind.StartTurn, c => c.StartTurnAsync(threadId, options, ct), ct);
+
+    /// <summary>
+    /// Forces a restart of the underlying app-server subprocess.
+    /// </summary>
+    public async Task RestartAsync(CancellationToken ct = default)
+    {
+        var version = Volatile.Read(ref _innerVersion);
+        await EnsureRestartedAsync(version, trigger: null, reason: "manual-restart", ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        _state = CodexAppServerConnectionState.Disposed;
+        _disposeCts.Cancel();
+
+        ICodexAppServerClientAdapter? inner;
+        await _restartLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            inner = _inner;
+            _inner = null;
+        }
+        finally
+        {
+            _restartLock.Release();
+        }
+
+        if (inner is not null)
+        {
+            try { await inner.DisposeAsync().ConfigureAwait(false); } catch { /* ignore */ }
+        }
+
+        try { _disposeCts.Dispose(); } catch { /* ignore */ }
+        _restartLock.Dispose();
+    }
+
+    private async Task<T> ExecuteWithPolicyAsync<T>(
+        CodexAppServerOperationKind kind,
+        Func<ICodexAppServerClientAdapter, Task<T>> op,
+        CancellationToken ct)
+    {
+        ThrowIfFaultedOrDisposed();
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _disposeCts.Token);
+        var linkedToken = linkedCts.Token;
+
+        var attempt = 0;
+        while (true)
+        {
+            linkedToken.ThrowIfCancellationRequested();
+            attempt++;
+
+            var inner = await EnsureConnectedAsync(linkedToken).ConfigureAwait(false);
+            var version = Volatile.Read(ref _innerVersion);
+
+            try
+            {
+                return await op(inner).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (IsDisconnect(ex))
+            {
+                RememberDisconnect(ex);
+
+                if (_options.AutoRestart)
+                {
+                    await EnsureRestartedAsync(version, ex, reason: kind.ToString(), linkedToken).ConfigureAwait(false);
+                }
+
+                ThrowIfFaultedOrDisposed();
+
+                var decision = await _options.RetryPolicy(new CodexAppServerRetryContext
+                {
+                    OperationKind = kind,
+                    Attempt = attempt,
+                    Exception = ex,
+                    CancellationToken = linkedToken,
+                    EnsureRestartedAsync = c => EnsureRestartedAsync(version, ex, reason: "policy-ensure-restarted", c)
+                }).ConfigureAwait(false);
+
+                if (!decision.ShouldRetry)
+                {
+                    throw;
+                }
+
+                if (decision.Delay is { } delay && delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, linkedToken).ConfigureAwait(false);
+                }
+
+                if (decision.BeforeRetryAsync is not null)
+                {
+                    await decision.BeforeRetryAsync(linkedToken).ConfigureAwait(false);
+                }
+
+                continue;
+            }
+        }
+    }
+
+    private async Task<ICodexAppServerClientAdapter> EnsureConnectedAsync(CancellationToken ct)
+    {
+        ThrowIfFaultedOrDisposed();
+
+        var existing = _inner;
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        await _restartLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            ThrowIfFaultedOrDisposed();
+
+            if (_inner is not null)
+            {
+                return _inner;
+            }
+
+            _state = CodexAppServerConnectionState.Restarting;
+            var created = await _startInner(ct).ConfigureAwait(false);
+            SetInner(created);
+            _state = CodexAppServerConnectionState.Connected;
+            return created;
+        }
+        finally
+        {
+            _restartLock.Release();
+        }
+    }
+
+    private async Task EnsureRestartedAsync(long expectedVersion, Exception? trigger, string? reason, CancellationToken ct)
+    {
+        ThrowIfFaultedOrDisposed();
+        ct.ThrowIfCancellationRequested();
+
+        await _restartLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            ThrowIfFaultedOrDisposed();
+
+            if (expectedVersion != Volatile.Read(ref _innerVersion))
+            {
+                return;
+            }
+
+            if (!_options.AutoRestart)
+            {
+                return;
+            }
+
+            _state = CodexAppServerConnectionState.Restarting;
+
+            var previousDisconnect = trigger as CodexAppServerDisconnectedException ?? _lastDisconnect;
+            var prevExitCode = previousDisconnect?.ExitCode;
+            var prevStderrTail = previousDisconnect?.StderrTail ?? Array.Empty<string>();
+
+            var policy = _options.RestartPolicy ?? CodexAppServerRestartPolicy.Default;
+
+            var previous = _inner;
+            _inner = null;
+
+            if (previous is not null)
+            {
+                try { await previous.DisposeAsync().ConfigureAwait(false); } catch { /* ignore */ }
+            }
+
+            Exception? lastStartFailure = null;
+            while (true)
+            {
+                // enforce restart window (sliding)
+                var now = DateTimeOffset.UtcNow;
+                while (_restartTimes.Count > 0 && (now - _restartTimes.Peek()) > policy.Window)
+                {
+                    _restartTimes.Dequeue();
+                }
+
+                if (_restartTimes.Count >= policy.MaxRestarts)
+                {
+                    var ex = new CodexAppServerUnavailableException(
+                        $"App-server restart limit reached ({policy.MaxRestarts} restarts within {policy.Window}).",
+                        innerException: lastStartFailure ?? trigger);
+                    Fault(ex);
+                    throw ex;
+                }
+
+                _restartTimes.Enqueue(now);
+                var windowAttempt = _restartTimes.Count;
+
+                var delay = ComputeBackoff(policy, windowAttempt);
+                if (delay > TimeSpan.Zero)
+                {
+                    _logger.LogDebug("Delaying app-server restart by {Delay} (attempt {Attempt} in window).", delay, windowAttempt);
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
+                }
+
+                try
+                {
+                    var created = await _startInner(ct).ConfigureAwait(false);
+                    SetInner(created);
+                    break;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    lastStartFailure = ex;
+                    _logger.LogWarning(ex, "Failed to restart codex app-server (attempt {Attempt} in window).", windowAttempt);
+                }
+            }
+
+            var restartCount = Interlocked.Increment(ref _restartCount);
+            var evt = new CodexAppServerRestartEvent
+            {
+                RestartCount = restartCount,
+                Timestamp = DateTimeOffset.UtcNow,
+                PreviousExitCode = prevExitCode,
+                Reason = reason,
+                PreviousStderrTail = prevStderrTail
+            };
+            LastRestart = evt;
+
+            try { _options.OnRestart?.Invoke(evt); } catch { /* ignore */ }
+
+            _logger.LogInformation("Restarted codex app-server (restart #{RestartCount}).", restartCount);
+            _state = CodexAppServerConnectionState.Connected;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var fail = ex is CodexAppServerUnavailableException
+                ? ex
+                : new CodexAppServerUnavailableException("Failed to restart codex app-server.", ex);
+            Fault(fail);
+            throw fail;
+        }
+        finally
+        {
+            _restartLock.Release();
+        }
+    }
+
+    private void SetInner(ICodexAppServerClientAdapter created)
+    {
+        _inner = created;
+        var newVersion = Interlocked.Increment(ref _innerVersion);
+
+        _exitMonitorTask = Task.Run(async () =>
+        {
+            try
+            {
+                await created.ExitTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            if (_disposeCts.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                await EnsureRestartedAsync(newVersion, trigger: _lastDisconnect, reason: "process-exited", _disposeCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // swallow - operations will surface fault if needed
+            }
+        });
+    }
+
+    private void Fault(Exception ex)
+    {
+        _fault = ex;
+        _state = CodexAppServerConnectionState.Faulted;
+    }
+
+    private void ThrowIfFaultedOrDisposed()
+    {
+        if (_state == CodexAppServerConnectionState.Disposed)
+        {
+            throw new ObjectDisposedException(nameof(ResilientCodexAppServerClient));
+        }
+
+        if (_fault is not null)
+        {
+            throw _fault;
+        }
+    }
+
+    private static TimeSpan ComputeBackoff(CodexAppServerRestartPolicy policy, int windowAttempt)
+    {
+        if (windowAttempt <= 1)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var exponent = windowAttempt - 2;
+        var factor = Math.Pow(2, Math.Min(exponent, 10));
+        var raw = TimeSpan.FromMilliseconds(policy.InitialBackoff.TotalMilliseconds * factor);
+        var capped = raw <= policy.MaxBackoff ? raw : policy.MaxBackoff;
+
+        var jitter = Math.Clamp(policy.JitterFraction, 0, 1);
+        if (jitter <= 0)
+        {
+            return capped;
+        }
+
+        var delta = capped.TotalMilliseconds * jitter;
+        var min = capped.TotalMilliseconds - delta;
+        var max = capped.TotalMilliseconds + delta;
+        var ms = min + (Random.Shared.NextDouble() * (max - min));
+        return TimeSpan.FromMilliseconds(Math.Max(0, ms));
+    }
+
+    private static bool IsDisconnect(Exception ex) =>
+        ex is CodexAppServerDisconnectedException ||
+        ex is JsonRpcConnectionClosedException ||
+        (ex is JsonRpcProtocolException p && p.InnerException is JsonRpcConnectionClosedException);
+
+    private void RememberDisconnect(Exception ex)
+    {
+        if (ex is CodexAppServerDisconnectedException d)
+        {
+            _lastDisconnect = d;
+        }
+    }
+
+    internal interface ICodexAppServerClientAdapter : IAsyncDisposable
+    {
+        Task ExitTask { get; }
+
+        Task<JsonElement> CallAsync(string method, object? @params, CancellationToken ct);
+
+        IAsyncEnumerable<AppServerNotification> Notifications(CancellationToken ct);
+
+        Task<CodexThread> StartThreadAsync(ThreadStartOptions options, CancellationToken ct);
+
+        Task<CodexThread> ResumeThreadAsync(string threadId, CancellationToken ct);
+
+        Task<CodexThread> ResumeThreadAsync(ThreadResumeOptions options, CancellationToken ct);
+
+        Task<CodexTurnHandle> StartTurnAsync(string threadId, TurnStartOptions options, CancellationToken ct);
+    }
+
+    private sealed class CodexAppServerClientAdapter : ICodexAppServerClientAdapter
+    {
+        private readonly CodexAppServerClient _inner;
+
+        public CodexAppServerClientAdapter(CodexAppServerClient inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        public Task ExitTask => _inner.ExitTask;
+
+        public Task<JsonElement> CallAsync(string method, object? @params, CancellationToken ct) => _inner.CallAsync(method, @params, ct);
+
+        public IAsyncEnumerable<AppServerNotification> Notifications(CancellationToken ct) => _inner.Notifications(ct);
+
+        public Task<CodexThread> StartThreadAsync(ThreadStartOptions options, CancellationToken ct) => _inner.StartThreadAsync(options, ct);
+
+        public Task<CodexThread> ResumeThreadAsync(string threadId, CancellationToken ct) => _inner.ResumeThreadAsync(threadId, ct);
+
+        public Task<CodexThread> ResumeThreadAsync(ThreadResumeOptions options, CancellationToken ct) => _inner.ResumeThreadAsync(options, ct);
+
+        public Task<CodexTurnHandle> StartTurnAsync(string threadId, TurnStartOptions options, CancellationToken ct) => _inner.StartTurnAsync(threadId, options, ct);
+
+        public ValueTask DisposeAsync() => _inner.DisposeAsync();
+    }
+}

--- a/src/JKToolKit.CodexSDK/AppServer/Resiliency/ServiceCollectionExtensions.cs
+++ b/src/JKToolKit.CodexSDK/AppServer/Resiliency/ServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using JKToolKit.CodexSDK.AppServer;
+
+namespace JKToolKit.CodexSDK.AppServer.Resiliency;
+
+/// <summary>
+/// Dependency injection extensions for registering resilient Codex app-server services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a resilient app-server client factory that can auto-restart the <c>codex app-server</c> subprocess.
+    /// </summary>
+    public static IServiceCollection AddCodexResilientAppServerClient(
+        this IServiceCollection services,
+        Action<CodexAppServerResilienceOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddCodexAppServerClient();
+        services.AddOptions();
+
+        if (configure is not null)
+        {
+            services.Configure(configure);
+        }
+
+        services.TryAddSingleton<ICodexResilientAppServerClientFactory, CodexResilientAppServerClientFactory>();
+
+        return services;
+    }
+
+    private sealed class CodexResilientAppServerClientFactory : ICodexResilientAppServerClientFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ICodexAppServerClientFactory _innerFactory;
+        private readonly IOptions<CodexAppServerResilienceOptions> _options;
+
+        public CodexResilientAppServerClientFactory(
+            IServiceProvider serviceProvider,
+            ICodexAppServerClientFactory innerFactory,
+            IOptions<CodexAppServerResilienceOptions> options)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _innerFactory = innerFactory ?? throw new ArgumentNullException(nameof(innerFactory));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public Task<ResilientCodexAppServerClient> StartAsync(CancellationToken ct = default)
+        {
+            var loggerFactory = _serviceProvider.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+
+            return ResilientCodexAppServerClient.StartAsync(
+                _innerFactory,
+                options: _options.Value,
+                loggerFactory: loggerFactory,
+                ct: ct);
+        }
+    }
+}

--- a/tests/JKToolKit.CodexSDK.Tests/Unit/ResilientCodexAppServerClientTests.cs
+++ b/tests/JKToolKit.CodexSDK.Tests/Unit/ResilientCodexAppServerClientTests.cs
@@ -1,0 +1,308 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using FluentAssertions;
+using JKToolKit.CodexSDK.AppServer;
+using JKToolKit.CodexSDK.AppServer.Notifications;
+using JKToolKit.CodexSDK.AppServer.Resiliency;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JKToolKit.CodexSDK.Tests.Unit;
+
+public sealed class ResilientCodexAppServerClientTests
+{
+    [Fact]
+    public async Task CallAsync_WhenDisconnected_Restarts_AndCanRetry_WhenPolicyAllows()
+    {
+        var first = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) => throw Disconnect("boom", exitCode: 42)
+        };
+
+        var second = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) =>
+            {
+                using var doc = JsonDocument.Parse("""{"ok":true}""");
+                return Task.FromResult(doc.RootElement.Clone());
+            }
+        };
+
+        var factory = new SequenceFactory(first, second);
+
+        var options = new CodexAppServerResilienceOptions
+        {
+            AutoRestart = true,
+            RetryPolicy = ctx => new ValueTask<CodexAppServerRetryDecision>(CodexAppServerRetryDecision.Retry())
+        };
+
+        await using var client = await StartAsync(factory, options);
+
+        var result = await client.CallAsync("ping", @params: null);
+        result.GetProperty("ok").GetBoolean().Should().BeTrue();
+        factory.StartCount.Should().Be(2);
+        client.RestartCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CallAsync_WhenDisconnected_DoesNotRetryByDefault_ButRestartsForNextCall()
+    {
+        var first = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) => throw Disconnect("boom", exitCode: 1)
+        };
+
+        var second = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) =>
+            {
+                using var doc = JsonDocument.Parse("""{"ok":true}""");
+                return Task.FromResult(doc.RootElement.Clone());
+            }
+        };
+
+        var factory = new SequenceFactory(first, second);
+        var options = new CodexAppServerResilienceOptions { AutoRestart = true };
+
+        await using var client = await StartAsync(factory, options);
+
+        var act = async () => await client.CallAsync("ping", @params: null);
+        await act.Should().ThrowAsync<CodexAppServerDisconnectedException>();
+
+        var result = await client.CallAsync("ping", @params: null);
+        result.GetProperty("ok").GetBoolean().Should().BeTrue();
+
+        factory.StartCount.Should().Be(2);
+        client.RestartCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Notifications_ContinueAcrossRestarts_AndEmitRestartMarker()
+    {
+        var first = new FakeAdapter
+        {
+            NotificationsImpl = FirstNotifications
+        };
+
+        var second = new FakeAdapter
+        {
+            NotificationsImpl = SecondNotifications
+        };
+
+        var factory = new SequenceFactory(first, second);
+        var options = new CodexAppServerResilienceOptions
+        {
+            AutoRestart = true,
+            NotificationsContinueAcrossRestarts = true,
+            EmitRestartMarkerNotifications = true
+        };
+
+        await using var client = await StartAsync(factory, options);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var seen = new List<string>();
+
+        await foreach (var n in client.Notifications(cts.Token))
+        {
+            seen.Add(n.Method);
+            if (seen.Count >= 3)
+                break;
+        }
+
+        seen.Should().ContainInOrder("note/one", "client/restarted", "note/two");
+        factory.StartCount.Should().Be(2);
+    }
+
+    private static async IAsyncEnumerable<AppServerNotification> FirstNotifications(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await Task.Yield();
+        yield return new UnknownNotification("note/one", EmptyJson());
+        throw Disconnect("nope", exitCode: 7);
+    }
+
+    private static async IAsyncEnumerable<AppServerNotification> SecondNotifications(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await Task.Yield();
+        yield return new UnknownNotification("note/two", EmptyJson());
+    }
+
+    [Fact]
+    public async Task RestartLimit_IsEnforced_AndClientFaults()
+    {
+        var first = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) => throw Disconnect("boom", exitCode: 2)
+        };
+
+        var second = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) => throw Disconnect("boom2", exitCode: 3)
+        };
+
+        var factory = new SequenceFactory(first, second);
+        var options = new CodexAppServerResilienceOptions
+        {
+            AutoRestart = true,
+            RestartPolicy = new CodexAppServerRestartPolicy
+            {
+                MaxRestarts = 1,
+                Window = TimeSpan.FromMinutes(1),
+                InitialBackoff = TimeSpan.Zero,
+                MaxBackoff = TimeSpan.Zero,
+                JitterFraction = 0
+            }
+        };
+
+        await using var client = await StartAsync(factory, options);
+
+        var act1 = async () => await client.CallAsync("ping", @params: null);
+        await act1.Should().ThrowAsync<CodexAppServerDisconnectedException>();
+
+        var act2 = async () => await client.CallAsync("ping", @params: null);
+        await act2.Should().ThrowAsync<CodexAppServerUnavailableException>();
+
+        client.State.Should().Be(CodexAppServerConnectionState.Faulted);
+    }
+
+    [Fact]
+    public async Task ConcurrentDisconnect_TriggersSingleRestart()
+    {
+        var first = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) => throw Disconnect("boom", exitCode: 1)
+        };
+
+        var second = new FakeAdapter
+        {
+            CallAsyncImpl = (_, _, _) =>
+            {
+                using var doc = JsonDocument.Parse("""{"ok":true}""");
+                return Task.FromResult(doc.RootElement.Clone());
+            }
+        };
+
+        var factory = new SequenceFactory(first, second);
+        var options = new CodexAppServerResilienceOptions
+        {
+            AutoRestart = true,
+            RetryPolicy = ctx => new ValueTask<CodexAppServerRetryDecision>(CodexAppServerRetryDecision.Retry())
+        };
+
+        await using var client = await StartAsync(factory, options);
+
+        var tasks = Enumerable.Range(0, 10).Select(async _ =>
+        {
+            var el = await client.CallAsync("ping", @params: null);
+            el.GetProperty("ok").GetBoolean().Should().BeTrue();
+        });
+
+        await Task.WhenAll(tasks);
+
+        factory.StartCount.Should().Be(2);
+        client.RestartCount.Should().Be(1);
+    }
+
+    private static async Task<ResilientCodexAppServerClient> StartAsync(
+        SequenceFactory factory,
+        CodexAppServerResilienceOptions options)
+    {
+        return await CreateResilientAsync(factory, options);
+    }
+
+    private static Task<ResilientCodexAppServerClient> CreateResilientAsync(
+        SequenceFactory factory,
+        CodexAppServerResilienceOptions options)
+    {
+        var logger = NullLogger.Instance;
+
+        var resilient = new ResilientCodexAppServerClient(
+            startInner: ct => Task.FromResult<ResilientCodexAppServerClient.ICodexAppServerClientAdapter>(factory.Start()),
+            options: options,
+            logger: logger);
+
+        return Task.FromResult(resilient);
+    }
+
+    private static CodexAppServerDisconnectedException Disconnect(string message, int exitCode) =>
+        new(
+            message,
+            processId: 123,
+            exitCode: exitCode,
+            stderrTail: new[] { "stderr: test" });
+
+    private static JsonElement EmptyJson()
+    {
+        using var doc = JsonDocument.Parse("{}");
+        return doc.RootElement.Clone();
+    }
+
+    private sealed class SequenceFactory
+    {
+        private readonly Queue<FakeAdapter> _queue;
+        public int StartCount { get; private set; }
+
+        public SequenceFactory(params FakeAdapter[] adapters)
+        {
+            _queue = new Queue<FakeAdapter>(adapters);
+        }
+
+        public FakeAdapter Start()
+        {
+            StartCount++;
+            return _queue.Count > 0 ? _queue.Dequeue() : new FakeAdapter();
+        }
+    }
+
+    private sealed class FakeAdapter : ResilientCodexAppServerClient.ICodexAppServerClientAdapter
+    {
+        private readonly TaskCompletionSource _exit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Func<string, object?, CancellationToken, Task<JsonElement>>? CallAsyncImpl { get; init; }
+
+        public Func<CancellationToken, IAsyncEnumerable<AppServerNotification>>? NotificationsImpl { get; init; }
+
+        public Task ExitTask => _exit.Task;
+
+        public Task<JsonElement> CallAsync(string method, object? @params, CancellationToken ct)
+        {
+            if (CallAsyncImpl is null)
+                throw new InvalidOperationException("CallAsyncImpl not configured.");
+            return CallAsyncImpl(method, @params, ct);
+        }
+
+        public IAsyncEnumerable<AppServerNotification> Notifications(CancellationToken ct)
+        {
+            if (NotificationsImpl is null)
+                return AsyncEnumerable.Empty<AppServerNotification>();
+            return NotificationsImpl(ct);
+        }
+
+        public Task<CodexThread> StartThreadAsync(ThreadStartOptions options, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<CodexThread> ResumeThreadAsync(string threadId, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<CodexThread> ResumeThreadAsync(ThreadResumeOptions options, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<CodexTurnHandle> StartTurnAsync(string threadId, TurnStartOptions options, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public ValueTask DisposeAsync()
+        {
+            _exit.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static class AsyncEnumerable
+    {
+        public static async IAsyncEnumerable<T> Empty<T>([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resilient app-server client with auto-restart, configurable retry/restart policies, backoff/jitter and restart limits.
  * Emits restart-marker notifications and exposes notification stream continuity across restarts.
  * Demo command to exercise multi-turn resilient streaming with restart handling.

* **Documentation**
  * Updated README with DI registration and usage examples for the resilient client.

* **Tests**
  * Unit tests covering restart/retry behavior, notification semantics, limits, and concurrent disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->