### PR TITLE
Make uncorrelated session log discovery optional

### DIFF
--- a/src/JKToolKit.CodexSDK/Exec/CodexClientOptions.cs
+++ b/src/JKToolKit.CodexSDK/Exec/CodexClientOptions.cs
@@ -19,6 +19,19 @@ public class CodexClientOptions
     private TimeSpan _tailPollInterval = TimeSpan.FromMilliseconds(200);
 
     /// <summary>
+    /// Gets or sets a value indicating whether the client may fall back to locating a newly created session log file
+    /// by scanning the sessions directory for <em>any</em> new JSONL file created around session start time.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, <see cref="CodexClient.StartSessionAsync(JKToolKit.CodexSDK.Exec.CodexSessionOptions,System.Threading.CancellationToken)"/>
+    /// may attach to the first matching session file created after the session start timestamp. This is helpful when
+    /// the session id emitted to stdout/stderr cannot be correlated to the JSONL filename, but it can be unsafe in
+    /// environments where multiple sessions may start concurrently (it can pick the wrong file).
+    /// Default is <c>false</c>.
+    /// </remarks>
+    public bool EnableUncorrelatedNewSessionFileDiscovery { get; set; }
+
+    /// <summary>
     /// Gets or sets the path to the Codex CLI executable.
     /// </summary>
     /// <remarks>
@@ -146,7 +159,8 @@ public class CodexClientOptions
         SessionsRootDirectory = SessionsRootDirectory,
         StartTimeout = StartTimeout,
         ProcessExitTimeout = ProcessExitTimeout,
-        TailPollInterval = TailPollInterval
+        TailPollInterval = TailPollInterval,
+        EnableUncorrelatedNewSessionFileDiscovery = EnableUncorrelatedNewSessionFileDiscovery
     };
 
     /// <summary>

--- a/src/JKToolKit.CodexSDK/Exec/CodexClientOptions.cs
+++ b/src/JKToolKit.CodexSDK/Exec/CodexClientOptions.cs
@@ -19,6 +19,16 @@ public class CodexClientOptions
     private TimeSpan _tailPollInterval = TimeSpan.FromMilliseconds(200);
 
     /// <summary>
+    /// Gets or sets a value indicating whether the client may include sanitized stdout/stderr snippets in thrown exceptions
+    /// during session startup failures.
+    /// </summary>
+    /// <remarks>
+    /// Default is <c>false</c>. When enabled, some exceptions from <see cref="CodexClient.StartSessionAsync(JKToolKit.CodexSDK.Exec.CodexSessionOptions,System.Threading.CancellationToken)"/>
+    /// may include a redacted prefix of the Codex process stdout/stderr to aid debugging.
+    /// </remarks>
+    public bool EnableDiagnosticCapture { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the client may fall back to locating a newly created session log file
     /// by scanning the sessions directory for <em>any</em> new JSONL file created around session start time.
     /// </summary>
@@ -160,7 +170,8 @@ public class CodexClientOptions
         StartTimeout = StartTimeout,
         ProcessExitTimeout = ProcessExitTimeout,
         TailPollInterval = TailPollInterval,
-        EnableUncorrelatedNewSessionFileDiscovery = EnableUncorrelatedNewSessionFileDiscovery
+        EnableUncorrelatedNewSessionFileDiscovery = EnableUncorrelatedNewSessionFileDiscovery,
+        EnableDiagnosticCapture = EnableDiagnosticCapture
     };
 
     /// <summary>

--- a/src/JKToolKit.CodexSDK/Infrastructure/CodexSessionLocator.cs
+++ b/src/JKToolKit.CodexSDK/Infrastructure/CodexSessionLocator.cs
@@ -17,7 +17,7 @@ namespace JKToolKit.CodexSDK.Infrastructure;
 /// including polling for new sessions, finding specific session logs, and enumerating
 /// sessions with optional filtering.
 /// </remarks>
-public sealed class CodexSessionLocator : ICodexSessionLocator
+public sealed partial class CodexSessionLocator : ICodexSessionLocator
 {
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<CodexSessionLocator> _logger;
@@ -26,9 +26,8 @@ public sealed class CodexSessionLocator : ICodexSessionLocator
     private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
 
     // Regex patterns for session file matching
-    private static readonly Regex SessionFilePattern = new(
-        @"^(rollout-.*\.jsonl|.*-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.jsonl)$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    [GeneratedRegex(@"^(rollout-.*\.jsonl|.*-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.jsonl)$", RegexOptions.IgnoreCase)]
+    private static partial Regex SessionFilePattern();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CodexSessionLocator"/> class.
@@ -353,7 +352,7 @@ public sealed class CodexSessionLocator : ICodexSessionLocator
             foreach (var file in existingFiles)
             {
                 var fileName = Path.GetFileName(file);
-                if (SessionFilePattern.IsMatch(fileName))
+                if (SessionFilePattern().IsMatch(fileName))
                 {
                     snapshot.Add(file);
                 }
@@ -389,7 +388,7 @@ public sealed class CodexSessionLocator : ICodexSessionLocator
                     var fileName = Path.GetFileName(filePath);
 
                     // Check if the file name matches the expected pattern
-                    if (!SessionFilePattern.IsMatch(fileName))
+                    if (!SessionFilePattern().IsMatch(fileName))
                     {
                         continue;
                     }
@@ -636,7 +635,7 @@ public sealed class CodexSessionLocator : ICodexSessionLocator
             }
 
             var fileName = Path.GetFileName(file);
-            if (!SessionFilePattern.IsMatch(fileName))
+            if (!SessionFilePattern().IsMatch(fileName))
             {
                 _logger.LogTrace("Skipping non-session file {FilePath}", file);
                 continue;

--- a/src/JKToolKit.CodexSDK/Infrastructure/CodexSessionLocator.cs
+++ b/src/JKToolKit.CodexSDK/Infrastructure/CodexSessionLocator.cs
@@ -69,7 +69,7 @@ public sealed class CodexSessionLocator : ICodexSessionLocator
         }
 
         _logger.LogDebug(
-            "Waiting for new session file in {Directory} created after {StartTime}",
+            "Waiting for any new session file in {Directory} created after {StartTime} (uncorrelated discovery)",
             sessionsRoot,
             startTime);
 

--- a/tests/JKToolKit.CodexSDK.Tests/Integration/CodexClientStartSessionTests.cs
+++ b/tests/JKToolKit.CodexSDK.Tests/Integration/CodexClientStartSessionTests.cs
@@ -78,7 +78,11 @@ public class CodexClientStartSessionTests
     public async Task StartSessionAsync_Fails_WhenProcessExitsBeforeSessionMeta()
     {
         // Arrange
-        var clientOptions = Options.Create(new CodexClientOptions { StartTimeout = TimeSpan.FromSeconds(2) });
+        var clientOptions = Options.Create(new CodexClientOptions
+        {
+            StartTimeout = TimeSpan.FromSeconds(2),
+            EnableUncorrelatedNewSessionFileDiscovery = true
+        });
         var workingDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), $"codex-tests-{Guid.NewGuid():N}")).FullName;
         var sessionOptions = new CodexSessionOptions(workingDirectory, "prompt");
 


### PR DESCRIPTION
- Adds CodexClientOptions.EnableUncorrelatedNewSessionFileDiscovery (default: false)
- StartSessionAsync only uses time-based "any new JSONL file" discovery when enabled
- Updates integration test that relied on uncorrelated discovery


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options to enable alternative session-file discovery and to include sanitized process output in startup failure details.

* **Improvements**
  * More robust session-start error handling with clearer, actionable messages and optional captured diagnostics.
  * Diagnostics are redacted automatically to remove sensitive tokens and identifiers.
  * Startup/cancellation paths hardened to produce consistent, informative exceptions.

* **Tests**
  * Integration tests updated to exercise the new discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->