### PR TITLE
chore(ci): run CI for upstream-sync PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: upstream-sync
@@ -76,6 +77,7 @@ jobs:
 
       - name: Create pull request
         if: steps.versions.outputs.up_to_date != 'true'
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           branch: automation/upstream-codex-${{ steps.versions.outputs.latest }}
@@ -87,3 +89,21 @@ jobs:
             - Previous: ${{ steps.versions.outputs.pinned }}
             - Latest: ${{ steps.versions.outputs.latest }}
           delete-branch: true
+
+      - name: Trigger CI for PR branch
+        if: steps.versions.outputs.up_to_date != 'true' && steps.cpr.outputs.pull-request-operation != 'none'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const workflowId = "ci.yml";
+            const ref = "automation/upstream-codex-${{ steps.versions.outputs.latest }}";
+
+            core.info(`Dispatching ${workflowId} on ${ref}`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              ref,
+            });


### PR DESCRIPTION
- Adds workflow_dispatch to CI so it can be dispatched via API\n- Upstream sync now dispatches CI on the generated PR branch so checks appear on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* CI workflow dispatch trigger has been added to enable manual workflow execution via GitHub Actions interface
* Upstream synchronization workflow has been updated with expanded GitHub Actions permissions and now automatically triggers CI validation checks for pull request branches created during upstream repository synchronization
* CI validation is now consistently applied across all upstream synchronization pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->